### PR TITLE
Fix dark theme issue for Dialog and Tabs

### DIFF
--- a/app/src/main/java/manparvesh/ideatrackerplus/MainActivity.java
+++ b/app/src/main/java/manparvesh/ideatrackerplus/MainActivity.java
@@ -1202,7 +1202,10 @@ public class MainActivity extends AppCompatActivity implements
 
     private void changeDarkTheme(boolean isDarkThemeEnabled) {
         mTinyDB.putBoolean(getString(R.string.dark_theme_pref), isDarkThemeEnabled);
-        recreate();
+
+        Intent intent = getIntent();
+        finish();
+        startActivity(intent);
     }
 
     @NonNull

--- a/app/src/main/java/manparvesh/ideatrackerplus/recycler/HorizontalAdapter.java
+++ b/app/src/main/java/manparvesh/ideatrackerplus/recycler/HorizontalAdapter.java
@@ -24,23 +24,20 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
     private String mIdea;
     private int mTabNumber;
 
-
     private View mLayout;
     private MyRecyclerView mRecyclerView;
     private View.OnLongClickListener mListener;
 
     // same text size for all ideas
     private static boolean mBigtext = false;
-
     private boolean mDarkTheme;
 
+    class MyViewHolder extends RecyclerView.ViewHolder {
+        TextView txtView;
+        TextView tabTag;
+        View priorityTag;
 
-    public class MyViewHolder extends RecyclerView.ViewHolder {
-        public TextView txtView;
-        public TextView tabTag;
-        public View priorityTag;
-
-        public MyViewHolder(View view) {
+        MyViewHolder(View view) {
             super(view);
             txtView = (TextView) view.findViewById(R.id.txtView);
             tabTag = (TextView) view.findViewById(R.id.tabTag);
@@ -48,24 +45,22 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
         }
     }
 
-
     public HorizontalAdapter(Context context, String text, int tabNumber, boolean darkTheme) {
         mIdea = text;
         mTabNumber = tabNumber;
         mLayout = LayoutInflater.from(context).inflate(R.layout.horizontal_item_view, null, false);
         mDarkTheme = darkTheme;
-
     }
 
     public static void setBigText(boolean b) {
         mBigtext = b;
     }
 
-    public void setLongClickListener(View.OnLongClickListener l) {
+    void setLongClickListener(View.OnLongClickListener l) {
         mListener = l;
     }
 
-    public void setIdeaText(String ideaText) {
+    void setIdeaText(String ideaText) {
         mIdea = ideaText;
     }
 
@@ -95,7 +90,7 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
         }
 
         //SEARCH TAB
-        int tab = mTabNumber; //The tab number the idea bealongs to
+        int tab = mTabNumber; //The tab number the idea belongs to
         if (mTabNumber == 4) {//Search tab
             tab = helper.getTabById((int) mRecyclerView.getTag());
 
@@ -125,7 +120,6 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
         //Fill the textView with the right content
         switch (tab) {
             case 1: //TAB#1 IDEA
-
                 switch (position) {
                     case 0: //Quick action send to DONE
                         holder.txtView.setText(R.string.done_caps);
@@ -135,31 +129,9 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
                         break;
 
                     case 1: //Idea text
-                        holder.txtView.setSingleLine();
-                        holder.txtView.setText(mIdea);
-                        holder.txtView.setGravity(Gravity.CENTER_VERTICAL | Gravity.START);
-                        if (mDarkTheme) {
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                container.setBackgroundResource(R.drawable.grey_ripple);
-                            } else {
-                                container.setBackgroundResource(R.color.md_blue_grey_800);
-                            }
-                            holder.txtView.setTextColor(Color.WHITE);
-                        } else {
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                container.setBackgroundResource(R.drawable.white_ripple);
-                            } else {
-                                container.setBackgroundResource(R.color.white);
-                            }
-                            holder.txtView.setTextColor(Color.BLACK);
-                        }
-                        //Listeners
-                        RecyclerOnClickListener listener = new RecyclerOnClickListener(mRecyclerView, mTabNumber);
-                        container.setOnClickListener(listener);
-                        container.setOnLongClickListener(mListener);
+                        setupIdeaTile(holder, container);
                         //Priority tag
-                        holder.priorityTag.setVisibility(View.VISIBLE);
-                        holder.priorityTag.setBackgroundResource(helper.getPriorityColorById((int) mRecyclerView.getTag()));
+                        setupPriorityTag(holder, helper);
                         break;
 
                     case 2: //Quick action send to LATER
@@ -172,7 +144,6 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
                 break;
 
             case 2: //TAB#2 LATER
-
                 switch (position) {
                     case 0: //Quick action send to NOW
                         holder.txtView.setText(R.string.now);
@@ -182,21 +153,9 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
                         break;
 
                     case 1: //Idea text
-                        holder.txtView.setSingleLine();
-                        holder.txtView.setText(mIdea);
-                        holder.txtView.setGravity(Gravity.CENTER_VERTICAL | Gravity.START);
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            container.setBackgroundResource(R.drawable.white_ripple);
-                        } else {
-                            container.setBackgroundResource(R.color.white);
-                        }
-                        holder.txtView.setTextColor(Color.DKGRAY);
-                        //Listeners
-                        RecyclerOnClickListener listener = new RecyclerOnClickListener(mRecyclerView, mTabNumber);
-                        container.setOnClickListener(listener);
-                        container.setOnLongClickListener(mListener);
-                        holder.priorityTag.setVisibility(View.VISIBLE);
-                        holder.priorityTag.setBackgroundResource(helper.getPriorityColorById((int) mRecyclerView.getTag()));
+                        setupIdeaTile(holder, container);
+                        //Priority tag
+                        setupPriorityTag(holder, helper);
                         break;
 
                     case 2: //Quick action send to DELETE
@@ -209,7 +168,6 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
                 break;
 
             case 3: //TAB#3 DONE
-
                 switch (position) {
                     case 0: //Quick action send to IDEAS
                         holder.txtView.setText(R.string.recover);
@@ -219,19 +177,8 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
                         break;
 
                     case 1: //idea text
-                        holder.txtView.setSingleLine();
-                        holder.txtView.setText(mIdea);
-                        holder.txtView.setGravity(Gravity.CENTER_VERTICAL | Gravity.START);
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            container.setBackgroundResource(R.drawable.white_ripple);
-                        } else {
-                            container.setBackgroundResource(R.color.white);
-                        }
-                        holder.txtView.setTextColor(Color.GRAY);
-                        //Listeners
-                        RecyclerOnClickListener listener = new RecyclerOnClickListener(mRecyclerView, mTabNumber);
-                        container.setOnClickListener(listener);
-                        container.setOnLongClickListener(mListener);
+                        setupIdeaTile(holder, container);
+                        //priority tag is not required for DONE tab
                         break;
 
                     case 2: //Quick action send to DELETE
@@ -242,16 +189,45 @@ public class HorizontalAdapter extends RecyclerView.Adapter<HorizontalAdapter.My
                         break;
                 }
                 break;
+        }
+    }
 
+    private void setupPriorityTag(MyViewHolder holder, DatabaseHelper helper) {
+        holder.priorityTag.setVisibility(View.VISIBLE);
+        holder.priorityTag.setBackgroundResource(helper.getPriorityColorById((int) mRecyclerView.getTag()));
+    }
+
+    private void setupIdeaTile(MyViewHolder holder, LinearLayout container) {
+        holder.txtView.setSingleLine();
+        holder.txtView.setText(mIdea);
+        holder.txtView.setGravity(Gravity.CENTER_VERTICAL | Gravity.START);
+
+        if (mDarkTheme) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                container.setBackgroundResource(R.drawable.grey_ripple);
+            } else {
+                container.setBackgroundResource(R.color.md_grey_800);
+            }
+            holder.txtView.setTextColor(Color.WHITE);
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                container.setBackgroundResource(R.drawable.white_ripple);
+            } else {
+                container.setBackgroundResource(R.color.white);
+            }
+            holder.txtView.setTextColor(Color.BLACK);
         }
 
+        //Listeners
+        RecyclerOnClickListener listener = new RecyclerOnClickListener(mRecyclerView, mTabNumber);
+        container.setOnClickListener(listener);
+        container.setOnLongClickListener(mListener);
     }
 
     @Override
     public void onAttachedToRecyclerView(RecyclerView recyclerView) {
         super.onAttachedToRecyclerView(recyclerView);
         mRecyclerView = (MyRecyclerView) recyclerView;
-
     }
 
     @Override

--- a/app/src/main/java/manparvesh/ideatrackerplus/recycler/RecyclerOnClickListener.java
+++ b/app/src/main/java/manparvesh/ideatrackerplus/recycler/RecyclerOnClickListener.java
@@ -1,6 +1,7 @@
 package manparvesh.ideatrackerplus.recycler;
 
 import android.app.Dialog;
+import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
@@ -29,6 +30,7 @@ import java.util.Locale;
 import manparvesh.ideatrackerplus.MainActivity;
 import manparvesh.ideatrackerplus.R;
 import manparvesh.ideatrackerplus.database.DatabaseHelper;
+import manparvesh.ideatrackerplus.database.TinyDB;
 
 /**
  * Created by Nicklos on 20/07/2016.
@@ -36,8 +38,10 @@ import manparvesh.ideatrackerplus.database.DatabaseHelper;
  */
 public class RecyclerOnClickListener implements View.OnClickListener, View.OnFocusChangeListener {
 
-    private MyRecyclerView mRecyclerView;
+    private Context context;
     private DatabaseHelper mDbHelper;
+    private MyRecyclerView mRecyclerView;
+    private boolean mDarkTheme;
 
     //RecyclerView attrs
     private int mIdRecycler;
@@ -59,14 +63,18 @@ public class RecyclerOnClickListener implements View.OnClickListener, View.OnFoc
     private static int mSecondaryColor;
 
     public RecyclerOnClickListener(MyRecyclerView recyclerView, int tabNumber) {
+        this.context = recyclerView.getContext();
         mRecyclerView = recyclerView;
         mTabNumber = tabNumber;
+
+        mDbHelper = DatabaseHelper.getInstance(context);
+        TinyDB mTinyDB = new TinyDB(context);
+        mDarkTheme = mTinyDB.getBoolean(context.getString(R.string.dark_theme_pref), false);
     }
 
     @Override
     public void onClick(View v) {
         mIdRecycler = (int) mRecyclerView.getTag();
-        mDbHelper = DatabaseHelper.getInstance(mRecyclerView.getContext());
         mPriority = mDbHelper.getPriorityById(mIdRecycler);
         showIdeaDialog();
     }
@@ -84,7 +92,7 @@ public class RecyclerOnClickListener implements View.OnClickListener, View.OnFoc
      * allows to delete or edit the idea
      */
     private void showIdeaDialog() {
-        mDetailedIdeaDialog = new LovelyCustomDialog(MainActivity.getInstance(), R.style.EditTextTintTheme)
+        mDetailedIdeaDialog = new LovelyCustomDialog(context, mDarkTheme ? R.style.EditTextTintThemeDark : R.style.EditTextTintTheme)
                 .setView(R.layout.detailed_idea_form)
                 .setTopColor(mPrimaryColor)
                 .setIcon(R.drawable.ic_bulb)
@@ -159,7 +167,7 @@ public class RecyclerOnClickListener implements View.OnClickListener, View.OnFoc
      * of the idea and showing the original ones.
      */
     public void editIdeaDialog() {
-        mEditIdeaDialog = new LovelyCustomDialog(MainActivity.getInstance(), R.style.EditTextTintTheme)
+        mEditIdeaDialog = new LovelyCustomDialog(context, mDarkTheme ? R.style.EditTextTintThemeDark : R.style.EditTextTintTheme)
                 .setView(R.layout.new_idea_form)
                 .setTopColor(mPrimaryColor)
                 .setIcon(R.drawable.ic_edit)

--- a/app/src/main/res/layout/detailed_idea_form.xml
+++ b/app/src/main/res/layout/detailed_idea_form.xml
@@ -21,7 +21,7 @@
             android:layout_marginLeft="8dp"
             android:layout_marginStart="8dp"
             android:text="@string/detailed_idea"
-            android:textColor="@color/md_black"
+            android:textColor="?android:attr/textColorPrimary"
             android:textSize="18sp"
             android:textStyle="bold" />
 

--- a/app/src/main/res/layout/horizontal_item_view.xml
+++ b/app/src/main/res/layout/horizontal_item_view.xml
@@ -14,19 +14,18 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
         android:clickable="true"
+        android:orientation="vertical"
         android:paddingBottom="16dp">
-
-
+        s
         <TextView
             android:id="@+id/txtView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="16dp"
+            android:ellipsize="end"
             android:paddingLeft="16dp"
             android:paddingRight="16dp"
-            android:ellipsize="end"
+            android:paddingTop="16dp"
             android:singleLine="true" />
 
         <TextView
@@ -35,8 +34,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="right"
             android:paddingRight="16dp"
-            android:text="@string/ideas"
-            android:visibility="gone" />
+            android:text="@string/ideas" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/new_idea_form.xml
+++ b/app/src/main/res/layout/new_idea_form.xml
@@ -2,9 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_marginBottom="16dp"
     android:layout_marginLeft="16dp"
     android:layout_marginRight="16dp"
-    android:layout_marginBottom="16dp"
     android:orientation="vertical"
     android:weightSum="1">
 
@@ -16,10 +16,10 @@
             android:id="@+id/idea_dialog_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
             android:layout_marginLeft="8dp"
             android:layout_marginStart="8dp"
             android:text="@string/new_idea"
-            android:layout_centerVertical="true"
             android:textColor="?android:attr/textColorPrimary"
             android:textSize="18sp"
             android:textStyle="bold" />
@@ -29,8 +29,8 @@
             style="?android:borderlessButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
             android:text="@string/create"
             android:textColor="@color/md_pink_a200" />
@@ -41,10 +41,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/hint_edit_idea"
-        android:textColorHint="@color/md_grey_500"
         android:imeOptions="actionDone"
         android:inputType="textCapSentences|textMultiLine"
-        android:textCursorDrawable="@drawable/edit_text_cursor"/>
+        android:textColorHint="@color/md_grey_500"
+        android:textCursorDrawable="@drawable/edit_text_cursor" />
 
     <TextView
         android:id="@+id/new_error_message"
@@ -61,9 +61,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/hint_edit_note"
-        android:textColorHint="@color/md_grey_500"
         android:inputType="textCapSentences|textMultiLine"
-        android:textCursorDrawable="@drawable/edit_text_cursor"/>
+        android:textColorHint="@color/md_grey_500"
+        android:textCursorDrawable="@drawable/edit_text_cursor" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -74,8 +74,8 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginRight="16dp"
             android:layout_marginEnd="16dp"
+            android:layout_marginRight="16dp"
             android:text="@string/priority"
             android:textSize="16sp" />
 
@@ -120,8 +120,8 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginRight="16dp"
             android:layout_marginEnd="16dp"
+            android:layout_marginRight="16dp"
             android:text="@string/do_later"
             android:textSize="16sp" />
 


### PR DESCRIPTION
#### Short description of what this resolves:
Dark theme feature has some minor issues where it's not applied to `mEditIdeaDialog` and `DetailedIdeaDialog`. Also, Dark Theme is applied to IDEAS tab only not LATER and DONE.

#### Changes proposed in this pull request:
- Activity restart with same intent instead of recreating. Change implementation of `MainActivity#changeDarkTheme` to finish activity first and start again with the same intent to apply dark theme in a proper way.
- Reformat `HorizontalAdapter` and extract logic to apply dark theme for IDEAS, LATER and DONE tabs. -
- Check for dark theme and apply dark theme or default theme to mEditIdeaDialog and DetailedIdeaDialog in `RecyclerViewOnClickListener`.
- Refactor `new_idea_form`, `detailed_idea_form` and `horizontal_idea_item`.

**Fixes**: #30 