### PR TITLE
Firebase base work plus automated UI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_script:
 script:
     - echo "Travis branch is $TRAVIS_BRANCH"
     - echo "Travis branch is in pull request $TRAVIS_PULL+REQUEST"
+    - yes | sudo sdkmanager --licenses
     - android-wait-for-emulator
     - adb devices   #Display list of devices
     - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
         - ANDROID_TARGET=android-22 ANDROID_ABI=armeabi-v7a
     global:
         - ADB_INSTALL_TIMEOUT=10    #Time out to 10 mins
+        - ANDROID_SDK_ROOT=/opt/android  # any place `travis` can write to should work
 
 before_cache:
     - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -38,7 +39,7 @@ licenses:
     - 'android-sdk-preview-license-.+'
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
-    - 'build-tools.+'
+    - 'build-tools;28.0.3'
 
 before_script:
     - chmod +x gradlew      #Grand permissions
@@ -57,6 +58,9 @@ script:
 
 before_install:
     - pip install --user codecov    #Install codecov
+    - - mkdir -p $ANDROID_SDK_ROOT
+    - yes | sdkmanager --sdk_root=$ANDROID_SDK_ROOT "tools" "build-tools;28.0.3" "extras;android;m2repository"
+    - export PATH=${ANDROID_SDK_ROOT}/tools/bin:$PATH
 
 after_success:
     - codecov                       #Run codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ licenses:
     - 'android-sdk-preview-license-.+'
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
+    - 'build-tools.+'
 
 before_script:
     - chmod +x gradlew      #Grand permissions

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
 
 before_install:
     - pip install --user codecov    #Install codecov
-    - - mkdir -p $ANDROID_SDK_ROOT
+    - mkdir -p $ANDROID_SDK_ROOT
     - yes | sdkmanager --sdk_root=$ANDROID_SDK_ROOT "tools" "build-tools;28.0.3" "extras;android;m2repository"
     - export PATH=${ANDROID_SDK_ROOT}/tools/bin:$PATH
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,15 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.gms.google-services'
 
 try {
     apply from: '../../../signing.gradle'
 } catch (ex) {
 }
-
 android {
 
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
     defaultConfig {
-        applicationId "appbox.gameideas"
+        applicationId "appbox.gameideasplus"
         minSdkVersion 16
         targetSdkVersion 23
         versionCode 9
@@ -25,25 +24,33 @@ android {
             debuggable true
         }
     }
+
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:design:23.4.0'
-    compile 'com.thebluealliance:spectrum:0.5.0'
-    compile('com.mikepenz:materialdrawer:5.3.6@aar') {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.google.firebase:firebase-core:16.0.7'
+
+    implementation 'com.google.firebase:firebase-firestore:18.0.1'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    implementation 'com.android.support:appcompat-v7:23.4.0'
+    implementation 'com.android.support:design:23.4.0'
+    implementation 'com.thebluealliance:spectrum:0.5.0'
+    implementation('com.mikepenz:materialdrawer:5.3.6@aar') {
         transitive = true
     }
-    compile 'com.mikepenz:google-material-typeface:2.2.0.1@aar'
-    compile 'com.mikepenz:fontawesome-typeface:4.4.0.1@aar'
-    compile 'com.yarolegovich:lovely-dialog:1.0.4'
-    compile 'com.github.paolorotolo:appintro:4.0.0'
-    compile 'com.github.iammert:MaterialIntroView:1.5.2'
-    compile 'com.github.woxthebox:draglistview:1.2.8'
-    compile 'com.github.ivbaranov:materialfavoritebutton:0.1.2'
-    compile 'com.github.mancj:MaterialSearchBar:0.3.1'
-    compile 'com.shehabic.droppy:Droppy:0.5.1@aar'
-    compile files('libs/gson-2.4.jar')
+    implementation 'com.mikepenz:google-material-typeface:2.2.0.1@aar'
+    implementation 'com.mikepenz:fontawesome-typeface:4.4.0.1@aar'
+    implementation 'com.yarolegovich:lovely-dialog:1.0.4'
+    implementation 'com.github.paolorotolo:appintro:4.0.0'
+    implementation 'com.github.iammert:MaterialIntroView:1.5.2'
+    implementation 'com.github.woxthebox:draglistview:1.2.8'
+    implementation 'com.github.ivbaranov:materialfavoritebutton:0.1.2'
+    implementation 'com.github.mancj:MaterialSearchBar:0.3.1'
+    implementation 'com.shehabic.droppy:Droppy:0.5.1@aar'
+    implementation files('libs/gson-2.4.jar')
+    configurations {
+        all*.exclude group: 'com.google.code.gson'
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,11 @@ android {
         targetSdkVersion 23
         versionCode 9
         versionName "0.1"
+        multiDexEnabled true
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        vectorDrawables.useSupportLibrary = true
+
     }
     buildTypes {
         release {
@@ -25,15 +30,19 @@ android {
         }
     }
 
+
 }
 
 dependencies {
+    implementation 'com.android.support:multidex:1.0.3'
+
+
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.google.firebase:firebase-core:16.0.7'
 
     implementation 'com.google.firebase:firebase-firestore:18.0.1'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'com.android.support:appcompat-v7:23.4.0'
     implementation 'com.android.support:appcompat-v7:23.4.0'
     implementation 'com.android.support:design:23.4.0'
     implementation 'com.thebluealliance:spectrum:0.5.0'
@@ -50,7 +59,32 @@ dependencies {
     implementation 'com.github.mancj:MaterialSearchBar:0.3.1'
     implementation 'com.shehabic.droppy:Droppy:0.5.1@aar'
     implementation files('libs/gson-2.4.jar')
+// AndroidJUnitRunner and JUnit Rules
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+
+// Espresso dependencies
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-intents:3.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-accessibility:3.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-web:3.0.1'
+    androidTestImplementation 'com.android.support.test.espresso.idling:idling-concurrent:3.0.1'
+
+// The following Espresso dependency can be either "compile"
+// or "androidTestCompile", depending on your app's implementation
+    androidTestImplementation 'com.android.support.test.espresso:espresso-idling-resource:3.0.1'
     configurations {
         all*.exclude group: 'com.google.code.gson'
+    }
+}
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        def requested = details.requested
+        if (requested.group == 'com.android.support') {
+            if (!requested.name.startsWith("multidex")) {
+                details.useVersion '23.4.0'
+            }
+        }
     }
 }

--- a/app/src/androidTest/java/manparvesh/ideatrackerplus/AbstractUITest.java
+++ b/app/src/androidTest/java/manparvesh/ideatrackerplus/AbstractUITest.java
@@ -1,0 +1,40 @@
+package manparvesh.ideatrackerplus;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.support.test.rule.ActivityTestRule;
+import android.support.v7.preference.PreferenceManager;
+
+import org.junit.Before;
+import org.junit.Rule;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+
+class AbstractUITest {
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class, true, false);
+
+    @Before
+    public void cleanUpConfig() {
+        Context context = getInstrumentation().getTargetContext();
+        SharedPreferences.Editor preferencesEditor = PreferenceManager.getDefaultSharedPreferences(context).edit();
+
+        // Set SharedPreferences data
+        preferencesEditor.putBoolean(context.getString(R.string.preference_firstStart), isIntrosActive());
+        preferencesEditor.putBoolean(context.getString(R.string.first_project_pref), isIntrosActive());
+        preferencesEditor.putBoolean(context.getString(R.string.clean_data), isCleanData());
+        preferencesEditor.commit();
+        // Launch activity
+        mActivityTestRule.launchActivity(new Intent());
+
+    }
+
+    public boolean isCleanData() {
+        return false;
+    }
+
+    protected boolean isIntrosActive() {
+        return true;
+    }
+}

--- a/app/src/androidTest/java/manparvesh/ideatrackerplus/AbstractUITest.java
+++ b/app/src/androidTest/java/manparvesh/ideatrackerplus/AbstractUITest.java
@@ -23,6 +23,8 @@ class AbstractUITest {
         // Set SharedPreferences data
         preferencesEditor.putBoolean(context.getString(R.string.preference_firstStart), isIntrosActive());
         preferencesEditor.putBoolean(context.getString(R.string.first_project_pref), isIntrosActive());
+        preferencesEditor.putBoolean(context.getString(R.string.right_drawer_pref), isIntrosActive());
+
         preferencesEditor.putBoolean(context.getString(R.string.clean_data), isCleanData());
         preferencesEditor.commit();
         // Launch activity

--- a/app/src/androidTest/java/manparvesh/ideatrackerplus/AddIdea.java
+++ b/app/src/androidTest/java/manparvesh/ideatrackerplus/AddIdea.java
@@ -1,0 +1,177 @@
+package manparvesh.ideatrackerplus;
+
+
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.action.ViewActions.swipeLeft;
+import static android.support.test.espresso.action.ViewActions.swipeRight;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class AddIdea extends AbstractUITest {
+    @Override
+    protected boolean isIntrosActive() {
+        return false;
+    }
+
+    //need to be ignored for now
+    //TODO:change to system.millis project to be independent of exisiting data
+    @Ignore
+    @Test
+    public void addIdea() {
+
+
+        ViewInteraction appCompatEditText = onView(
+                allOf(withId(R.id.editProjectName),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.ld_custom_view_container),
+                                        0),
+                                1)));
+        appCompatEditText.perform(scrollTo(), replaceText("Hallo test"), closeSoftKeyboard());
+
+        ViewInteraction appCompatButton = onView(
+                allOf(withId(R.id.projectDoneButton), withText("CREATE"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withClassName(is("android.widget.LinearLayout")),
+                                        0),
+                                1),
+                        isDisplayed()));
+        appCompatButton.perform(click());
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction floatingActionButton = onView(
+                allOf(withId(R.id.fab),
+                        childAtPosition(
+                                allOf(withId(R.id.main_content),
+                                        childAtPosition(
+                                                withId(R.id.material_drawer_layout),
+                                                0)),
+                                1),
+                        isDisplayed()));
+        floatingActionButton.perform(click());
+
+        ViewInteraction appCompatEditText2 = onView(
+                allOf(withId(R.id.editText),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.ld_custom_view_container),
+                                        0),
+                                1)));
+        appCompatEditText2.perform(scrollTo(), replaceText("Test"), closeSoftKeyboard());
+
+        ViewInteraction appCompatButton2 = onView(
+                allOf(withId(R.id.doneButton), withText("CREATE"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withClassName(is("android.widget.LinearLayout")),
+                                        0),
+                                1),
+                        isDisplayed()));
+        appCompatButton2.perform(click());
+
+        ViewInteraction tabView = onView(
+                allOf(childAtPosition(
+                        childAtPosition(
+                                withId(R.id.tabLayout),
+                                0),
+                        1),
+                        isDisplayed()));
+        tabView.perform(click());
+
+        ViewInteraction nonSwipeableViewPager = onView(
+                allOf(withId(R.id.container),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.main_content),
+                                        0),
+                                1),
+                        isDisplayed()));
+        nonSwipeableViewPager.perform(swipeLeft());
+
+        ViewInteraction tabView2 = onView(
+                allOf(childAtPosition(
+                        childAtPosition(
+                                withId(R.id.tabLayout),
+                                0),
+                        0),
+                        isDisplayed()));
+        tabView2.perform(click());
+
+        ViewInteraction nonSwipeableViewPager2 = onView(
+                allOf(withId(R.id.container),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.main_content),
+                                        0),
+                                1),
+                        isDisplayed()));
+        nonSwipeableViewPager2.perform(swipeRight());
+
+        ViewInteraction textView = onView(
+                allOf(withId(R.id.txtView), withText("Test"),
+                        childAtPosition(
+                                childAtPosition(
+                                        IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class),
+                                        1),
+                                0),
+                        isDisplayed()));
+        textView.check(matches(withText("Test")));
+    }
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/app/src/androidTest/java/manparvesh/ideatrackerplus/AddProject.java
+++ b/app/src/androidTest/java/manparvesh/ideatrackerplus/AddProject.java
@@ -1,0 +1,170 @@
+package manparvesh.ideatrackerplus;
+
+
+import android.content.Intent;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.pressBack;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
+import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withResourceName;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class AddProject extends AbstractUITest {
+
+    @Override
+    protected boolean isIntrosActive() {
+        return false;
+    }
+
+    @Override
+    public boolean isCleanData() {
+        return true;
+    }
+
+    @Test
+    public void addProject() {
+        ViewInteraction leftDrawerButton = onView(
+                allOf(withContentDescription("Open"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withId(R.id.appbar),
+                                                0)),
+                                1),
+                        isDisplayed()));
+        leftDrawerButton.perform(click());
+
+        ViewInteraction openProjectList = onView(
+                allOf(allOf(withId(R.id.material_drawer_recycler_view), hasFocus()),
+                        childAtPosition(
+                                withId(R.id.material_drawer_slider_layout),
+                                1)));
+        openProjectList.perform(actionOnItemAtPosition(5, click()));
+
+        ViewInteraction appCompatEditText = onView(
+                allOf(withId(R.id.editProjectName),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.ld_custom_view_container),
+                                        0),
+                                1)));
+        String addProjectTest = "Ad"+System.currentTimeMillis();
+        appCompatEditText.perform(scrollTo(), replaceText(addProjectTest), closeSoftKeyboard());
+
+        ViewInteraction appCompatButton = onView(
+                allOf(withId(R.id.projectDoneButton), withText("CREATE"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withClassName(is("android.widget.LinearLayout")),
+                                        0),
+                                1),
+                        isDisplayed()));
+        appCompatButton.perform(click());
+
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        onView(allOf(withId(R.id.material_drawer_recycler_view), hasFocus())).perform(pressBack());
+        ViewInteraction textView = onView(
+                allOf(withText(addProjectTest)
+                        ,
+                        isDisplayed()));
+        textView.check(matches(withText(addProjectTest)));
+        leftDrawerButton.perform(click());
+        openProjectList.perform(actionOnItemAtPosition(4, click()));
+
+        ViewInteraction textView2 = onView(
+                allOf(withResourceName("material_drawer_email"), withText(addProjectTest),
+                        isDisplayed()));
+        textView2.check(matches(withText(addProjectTest)));
+        textView2.perform(click());
+
+
+        leftDrawerButton.perform(click());
+
+
+        ViewInteraction recyclerView3 = onView(
+                allOf(allOf(withId(R.id.material_drawer_recycler_view), hasFocus()),
+                        childAtPosition(
+                                withId(R.id.material_drawer_slider_layout),
+                                1)));
+        recyclerView3.perform(actionOnItemAtPosition(2, click()));
+
+        ViewInteraction deleteButton = onView(
+                allOf(withId(R.id.ld_btn_yes), withText("DELETE"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withClassName(is("android.widget.LinearLayout")),
+                                        2),
+                                3),
+                        isDisplayed()));
+
+        deleteButton.perform(click());
+        leftDrawerButton.perform(click());
+        openProjectList.perform(actionOnItemAtPosition(4, click()));
+
+        ViewInteraction textView3 = onView(
+                allOf(withId(R.id.material_drawer_email), withText(addProjectTest),
+                        childAtPosition(
+                                childAtPosition(
+                                        IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class),
+                                        1),
+                                0),
+                        isDisplayed()));
+        textView3.check(doesNotExist());
+    }
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/app/src/androidTest/java/manparvesh/ideatrackerplus/IntroTest.java
+++ b/app/src/androidTest/java/manparvesh/ideatrackerplus/IntroTest.java
@@ -1,0 +1,131 @@
+package manparvesh.ideatrackerplus;
+
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.preference.PreferenceManager;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.swipeLeft;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
+import static android.support.test.espresso.matcher.ViewMatchers.withResourceName;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class IntroTest {
+
+    @Rule
+    public ActivityTestRule<MyIntro> mMyIntroTestRule = new ActivityTestRule<>(MyIntro.class);
+
+    @Test
+    public void introTest() {
+
+        ViewInteraction textView = onView(
+                allOf(withId(R.id.description), withText("All your ideas and tasks\nin one place"),
+                        childAtPosition(
+                                allOf(withId(R.id.main),
+                                        withParent(withId(R.id.view_pager))),
+                                2),
+                        isDisplayed()));
+        textView.check(matches(withText("All your ideas and tasks\nin one place")));
+
+        ViewInteraction appCompatImageButton = onView(
+                allOf(withId(R.id.next),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.bottom),
+                                        1),
+                                2),
+                        isDisplayed()));
+        appCompatImageButton.perform(click());
+
+        ViewInteraction appIntroViewPager = onView(
+                allOf(withId(R.id.view_pager),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(android.R.id.content),
+                                        0),
+                                1),
+                        isDisplayed()));
+        appIntroViewPager.perform(swipeLeft());
+
+        ViewInteraction textView2 = onView(allOf(allOf(withResourceName("description"), withText("Class your ideas in projects\nto stay on focus")),
+                childAtPosition(
+                        allOf(withId(R.id.main),
+                                withParent(withId(R.id.view_pager))),
+                        2),
+                isDisplayed()));
+        textView2.check(matches(withText("Class your ideas in projects\nto stay on focus")));
+
+        ViewInteraction appIntroViewPager2 = onView(
+                allOf(withId(R.id.view_pager),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(android.R.id.content),
+                                        0),
+                                1),
+                        isDisplayed()));
+        appIntroViewPager2.perform(swipeLeft());
+
+        ViewInteraction textView3 = onView(
+                allOf(withId(R.id.description), withText("And keep track of your progress"),
+                        childAtPosition(
+                                allOf(withId(R.id.main),
+                                        withParent(withId(R.id.view_pager))),
+                                2),
+                        isDisplayed()));
+        textView3.check(matches(withText("And keep track of your progress")));
+
+        ViewInteraction appCompatImageButton3 = onView(
+                allOf(withId(R.id.done),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.bottom),
+                                        1),
+                                3),
+                        isDisplayed()));
+        appCompatImageButton3.perform(click());
+    }
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/app/src/androidTest/java/manparvesh/ideatrackerplus/SimpleTest.java
+++ b/app/src/androidTest/java/manparvesh/ideatrackerplus/SimpleTest.java
@@ -1,0 +1,92 @@
+package manparvesh.ideatrackerplus;
+
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.ViewAssertion;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.preference.PreferenceManager;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import static android.provider.Settings.System.getString;
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class SimpleTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class, true, false);
+
+
+    @Before
+    public void cleanUpConfig() {
+        Context context = getInstrumentation().getTargetContext();
+        SharedPreferences.Editor preferencesEditor = PreferenceManager.getDefaultSharedPreferences(context).edit();
+
+        // Set SharedPreferences data
+        preferencesEditor.putBoolean(context.getString(R.string.preference_firstStart), true).commit();
+
+        // Launch activity
+        mActivityTestRule.launchActivity(new Intent());
+
+    }
+
+    @Test
+    public void simpleTest() {
+        ViewInteraction appCompatImageButton = onView(
+                allOf(withId(R.id.skip),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.bottom),
+                                        1),
+                                1),
+                        isDisplayed()));
+        appCompatImageButton.perform(click());
+    }
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/app/src/main/java/manparvesh/ideatrackerplus/MainActivity.java
+++ b/app/src/main/java/manparvesh/ideatrackerplus/MainActivity.java
@@ -426,7 +426,7 @@ public class MainActivity extends AppCompatActivity implements
                         new PrimaryDrawerItem().withIdentifier(ID_NEW_PROJECT_AND_SWITCH).withName(R.string.new_pro).withIcon(FontAwesome.Icon.faw_plus).withSelectable(false),
                         new DividerDrawerItem(),
                         new ExpandableDrawerItem().withName(R.string.settings).withIcon(FontAwesome.Icon.faw_gear).withSelectable(false).withSubItems(
-                                doneSwitch, bigTextSwitch, darkSwitch, fireStoreSwitch),
+                                doneSwitch, bigTextSwitch, darkSwitch/*, fireStoreSwitch*/),
                         new ExpandableDrawerItem().withName(R.string.help_feedback).withIcon(FontAwesome.Icon.faw_question_circle).withSelectable(false).withSubItems(
                                 new SecondaryDrawerItem().withName(R.string.see_app_intro).withLevel(2).withIcon(GoogleMaterial.Icon.gmd_camera_rear).withIdentifier(ID_SEE_APP_INTRO_AGAIN).withSelectable(false),
                                 new SecondaryDrawerItem().withName(R.string.activate_tuto).withLevel(2).withIcon(GoogleMaterial.Icon.gmd_info).withIdentifier(ID_ACTIVATE_TUTORIAL_AGAIN).withSelectable(false),
@@ -1137,8 +1137,7 @@ public class MainActivity extends AppCompatActivity implements
                 })
                 .setUsageId("right_drawer") //THIS SHOULD BE UNIQUE ID
                 .show();
-
-        mTinyDB.putBoolean(getString(R.string.right_drawer_pref), false);
+        preferencesEditor.edit().putBoolean(getString(R.string.right_drawer_pref),false).commit();
     }
 
     private MyMaterialIntroView menuIdeaGuide(View fabView) {
@@ -1870,7 +1869,7 @@ public class MainActivity extends AppCompatActivity implements
                                     mTinyDB.putBoolean(getString(R.string.handle_idea_pref), true);
                                     preferencesEditor.edit().putBoolean(getString(R.string.first_project_pref),true).commit();
                                     mTinyDB.putBoolean(getString(R.string.first_idea_pref), true);
-                                    mTinyDB.putBoolean(getString(R.string.right_drawer_pref), true);
+                                    preferencesEditor.edit().putBoolean(getString(R.string.right_drawer_pref),true).commit();
                                     mTinyDB.putBoolean(getString(R.string.idea_menu_pref), true);
                                 }
                             });
@@ -1933,7 +1932,7 @@ public class MainActivity extends AppCompatActivity implements
     @Override
     public void onDrawerClosed(View drawerView) {
 
-        if (mTinyDB.getBoolean(getString(R.string.right_drawer_pref)) && !mNoProject && !mHandleFilter) {//Left drawer closed
+        if (preferencesEditor.getBoolean(getString(R.string.right_drawer_pref),true) && !mNoProject && !mHandleFilter) {//Left drawer closed
             rightDrawerGuide();
         } else if (mTinyDB.getBoolean(getString(R.string.first_idea_pref)) && !mNoProject && mHandleFilter) {
             firstIdeaGuide();

--- a/app/src/main/java/manparvesh/ideatrackerplus/MyIntro.java
+++ b/app/src/main/java/manparvesh/ideatrackerplus/MyIntro.java
@@ -39,10 +39,11 @@ public class MyIntro extends AppIntro2 {
     }
 
     private void goToMainActivity() {
-        Intent i = new Intent(MyIntro.this, MainActivity.class);
+      /*  Intent i = new Intent(MyIntro.this, MainActivity.class);
         i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
                 Intent.FLAG_ACTIVITY_CLEAR_TASK |
                 Intent.FLAG_ACTIVITY_NEW_TASK);
-        startActivity(i);
+        startActivity(i);*/
+        finish();
     }
 }

--- a/app/src/main/java/manparvesh/ideatrackerplus/database/DatabaseHelper.java
+++ b/app/src/main/java/manparvesh/ideatrackerplus/database/DatabaseHelper.java
@@ -1003,7 +1003,5 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         //Send the newly ordered lists for display
         notifyAllLists();
     }
-
-
 }
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -75,6 +75,10 @@
     <string name="welcome_content">Toutes vos idées et tâches\nréunies en une seule app</string>
     <string name="edit">MODIFIER</string>
     <string name="save">Sauvegarder</string>
+    <string name="idea_menu_pref">firstIdeaMenu</string>
+
+    <string name="detailed_idea">Idea details</string>
+    <string name="preference_firstStart">firstStart</string>
 
     <string-array name="array_from">
         <item>Terminé</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,9 @@
     <string name="idea_menu_pref">firstIdeaMenu</string>
     <string name="save">Save</string>
     <string name="detailed_idea">Idea details</string>
+    <string name="preference_firstStart">firstStart</string>
+    <string name="clean_data">clean_data</string>
+
 
     <string-array name="array_from">
         <item>Done</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="all_pro">All projects</string>
     <string name="new_pro">New project</string>
     <string name="dark_col">Dark Theme</string>
+    <string name="firestore_col">Cloud Storage (Google)</string>
     <string name="primary_col">Primary color</string>
     <string name="secondary_col">Secondary color</string>
     <string name="text_col">Text color</string>
@@ -55,6 +56,7 @@
     <string name="help">Help</string>
     <string name="tuto_mode">Tutorial mode is now active</string>
     <string name="dark_theme_pref" translatable="false">darkTheme</string>
+    <string name="firestore_pref" translatable="false">fireStore</string>
     <string name="show_done_pref" translatable="false">showDone</string>
     <string name="show_done_msg">Show Done tab</string>
     <string name="big_text_pref" translatable="false">bigTextSwitch</string>

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,11 @@ buildscript {
         maven {
             url "https://jitpack.io"
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.google.gms:google-services:4.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -17,6 +19,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven {
             url "https://jitpack.io"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jun 18 12:07:57 SGT 2017
+#Thu Feb 21 20:51:21 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 21 20:51:21 CET 2019
+#Sun Feb 24 07:11:47 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip


### PR DESCRIPTION
refs #27 
#### Short description of what this resolves:
Include of firebase base work. For this I needed also to change the appid (change it back later if you want)
Before I dive deeper into the firebase stuff and refactoring of the databaseHelper I wanted to have some tests. So I wrote some automated UI tests. I will do this for all storage operations before I touche the databaseHelper. 
#### Changes proposed in this pull request:

- added automated UI tests
- Integrated the base for firebase (aka firestore actually)
- started to use the preferencesEditor instead of the tinyDB (this allows to inject different states from the tests, so that the intros are skipped etc...)

**Fixes**: # move from tinyDB to preferencesEditor for preferences.